### PR TITLE
changed BaseShader._shaderid protection level

### DIFF
--- a/source/dglsl/shader.d
+++ b/source/dglsl/shader.d
@@ -13,7 +13,7 @@ import dglsl.translator;
 class ShaderBase {
     mixin TextureLookupFunctions;
 
-    private GLuint _shaderid;
+    protected GLuint _shaderid;
     @property auto id() const { return _shaderid; }
 }
 


### PR DESCRIPTION
When is its private, it can't be accessed by template methods instantiated in other modules. I think this was triggered by fixes to d frontend's visibility handling.
